### PR TITLE
Example: Use the preferred import style

### DIFF
--- a/example/app.py
+++ b/example/app.py
@@ -1,5 +1,5 @@
 from flask import Flask, render_template
-from flask_gears import Gears
+from flask.ext.gears import Gears
 
 from gears_stylus import StylusCompiler
 from gears_clean_css import CleanCSSCompressor


### PR DESCRIPTION
[Using Flask Extensions](http://flask.readthedocs.org/en/latest/extensions/#using-extensions) suggests to import like `from flask.ext import foo`.
